### PR TITLE
Add .isort.cfg compatible with black

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,6 @@
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88


### PR DESCRIPTION
Example copied from https://github.com/psf/black#how-black-wraps-lines

Reference: https://github.com/timothycrosley/isort/wiki/isort-Settings