### PR TITLE
Fjerner utdatert "safe" attribute

### DIFF
--- a/nablapps/image/markdownprocessing.py
+++ b/nablapps/image/markdownprocessing.py
@@ -63,9 +63,9 @@ class ImagePreprocessor(markdown.preprocessors.Preprocessor):
                     yield "".join(
                         [
                             image_match.group("before"),
-                            store(html_before, safe=True),
+                            store(html_before),
                             "\n".join(caption_lines),
-                            store(html_after, safe=True),
+                            store(html_after),
                             image_match.group("after"),
                         ]
                     )


### PR DESCRIPTION
Pønsket langt og lenge på hva i all verden som kunne være unsafe med den
HTML-snutten som genereres her og lekte litt med bleach pakken, men jeg
kom frem til at dette var mye styr for ingen grunn. Django templaten
escaper alt potensielt tull, og det som sendes inn er dessuten kun
predefinerte ord. Caption er fortsatt markert som "safe" i templaten, så
man kan fortsatt bruke HTML der. Dette ser ut til å være med hensikt,
men usikker på hvor det blir brukt. Lar den være for å ikke ødelegge for
sidene som muligens bruker det. Er vel kun staff som kan bruke denne
taggen, så det er nok ok uansett.