### PR TITLE
Add workflows for testing and linting

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,43 @@
+name: Python linting
+
+on: [push, workflow_dispatch]
+
+jobs:
+  check-formatting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install black flake8 isort>=5.0
+    - name: Check for serious errors with flake8
+      run: make check-fatal
+    - name: Check formatting with black and isort
+      run: make check-formatting
+
+  report-linting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pylint bandit
+
+    - name: Report linting errors with flake8
+      run: make report-flake8
+
+    - name: Report linting errors with pylint
+      run: make report-pylint
+
+    - name: Report security audit with bandit
+      run: make report-bandit

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,72 @@
+name: Python testing
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  test:
+    env:
+      # Have the venv be in the project folder so it is easier to cache
+      PIPENV_VENV_IN_PROJECT: true
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        python_version: [3.6]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python_version }}
+    - name: Install pipenv
+      run: |
+        python -m pip install --upgrade pip
+        pip install pipenv
+    - name: Cache virtualenv
+      id: cache-venv
+      uses: actions/cache@v2
+      env:
+        CACHE_NAME: CACHE_VIRTUALENV
+      with:
+        path: .venv
+        key: >
+          ${{ runner.os }}-${{ env.CACHE_NAME }}-python${{ matrix.python_version }}-${{ hashFiles('Pipfile.lock') }}
+        # Fallbacks to partially restore cache
+        restore-keys: |
+          ${{ runner.os }}-${{ env.CACHE_NAME }}-python${{ matrix.python_version }}-
+          ${{ runner.os }}-${{ env.CACHE_NAME }}-
+    - name: Install dependencies
+      if: steps.cache-venv.outputs.cache-hit != 'true'
+      run: |
+        # Force copying dependencies into the venv to prevent an error on windows
+        python -m venv --copies .venv
+        # Install dependencies into the newly created venv
+        pipenv install --deploy --dev
+
+    - name: Allow reading and writing PDFs (linux only)
+      # Edit imagemagick's policy file to allow reading and writing PDFs
+      # This is needed to create Nablad instances, which is done during testing
+      if: runner.os == 'Linux'
+      run: |
+        configure_path=$(convert -list configure | sed -n -e 's/CONFIGURE_PATH[[:space:]]*//p')
+        sudo sed -i -e 's/<policy domain="coder" rights=".*" pattern="PDF" \/>/<policy domain="coder" rights="read | write" pattern="PDF" \/>/' "${configure_path}policy.xml"
+
+    - name: Exclude tests that need ImageMagick (non-linux)
+      # ImageMagick does not come pre-installed on mac- and windows runners, so we skip
+      # tests that need it on those hosts. This is done by excluding a specific test tag,
+      # which is set on the test that needs ImageMagick
+      if: runner.os != 'Linux'
+      run: |
+        echo '::set-env name=exclude_tag::needs_imagemagick'
+
+    - name: Run tests
+      # Tests are run in parallel, which may cause issues if the tests aren't propertly isolated
+      run: |
+        pipenv run python manage.py test --parallel --exclude-tag=${{ env.exclude_tag }}


### PR DESCRIPTION
I have added github actions for linting and testing the code.

Before this, one of our tests were failing, and I had no idea. I fixed this in 6bd57820b3131efbb13b8f97910fcde344aa0e36.
We also had some incorrect formatting (681b3d6b3f1120d55c2a1c77d85cbc986548f216). This should be way easier to spot moving forward.

1. The linting workflow runs on push to any branch and checks the formatting of the code with black and isort. It also reports on linting errors from flake8 and pylint, and security warnings from bandit, but these are not required to pass for the run to succeed. In the future we could require a pass from flake8 to succeed, as we are pretty close to passing as is. (Though with a very lenient ruleset)

2. The testing workflow runs on push/pull request to master and runs the tests on mac, windows and linux. The test that requires `ImageMagick` is only run on linux because the windows- and mac runners don't have it pre-installed.

Both actions also run on `workflow_dispatch` and can be triggered on any branch at any time by going to the actions tab and selecting the action. Useful if you want to run the tests on your branch without having to create a PR.

Thoughts? Suggestions? Improvements?