### PR TITLE
Register user to popup

### DIFF
--- a/nablapps/accounts/signals.py
+++ b/nablapps/accounts/signals.py
@@ -12,19 +12,11 @@ def login_message(sender, request, user, **kwargs):
         msg = f"Velkommen inn <strong>{escape(user.username)}</strong>"
         messages.info(request, mark_safe(msg))
 
-    with suppress(MessageFailure):
-        msg = f"Er du på Campus? Bidra med å holde Campus åpent ved å skanne QR-koden på rommet du befinner deg i <3"  # reklame eSKE/SKE - kan også brukes til annet
-        messages.error(request, mark_safe(msg))
-
 
 def logout_message(sender, request, user, **kwargs):
     with suppress(MessageFailure):
         msg = f"<strong>{escape(user.username)} </strong> ble logget ut"
         messages.info(request, mark_safe(msg))
-
-    with suppress(MessageFailure):
-        msg = f"Er du på Campus? Bidra med å holde Campus åpent ved å skanne QR-koden på rommet du befinner deg i <3"  # reklame eSKE/SKE - kan også brukes til annet
-        messages.error(request, mark_safe(msg))
 
 
 def register_signals():

--- a/nablapps/contact/views.py
+++ b/nablapps/contact/views.py
@@ -92,7 +92,7 @@ def make_contact_context(request, spam_check, test_val):
         ("Ambassadør", "ambassador"),
         ("Websjef", "websjef"),
         ("Redaktør", "redaktor"),
-        ("PR-sjef", "leder.prokom")
+        ("PR-sjef", "leder.prokom"),
     )
     nabla_pos_emails = (
         ("Alle gruppeledere", "gruppeledere"),

--- a/templates/base.html
+++ b/templates/base.html
@@ -182,9 +182,14 @@
                             Trykk her for påmelding til fadderperioden - <b>2021!</b>
                         </a>
                         <p>
-                            Registreringen tar 10 sekunder, og vi understreker igjen at det er viktig at du gjør dette!
+                            Påmeldingen tar 10 sekunder, og vi understreker igjen at det er viktig at du gjør dette!
                             Gjør dette nå, og så kan du lese resten av informasjonen senere.
                         </p>
+                        <!-- <a href="https://nabla.no/brukere/registrer/"
+                        class="btn btn-warning btn-lg btn-block my-1"
+                        style="white-space:normal">
+                         Trykk her for å registrere deg en bruker på <b>Nabla.no</b>
+                     </a> -->
                         <div class="list-group">
                             <a href="nystudent" class="list-group-item list-group-item-action" style="color:black">
                                 Mer informasjon om fadderopplegget finner du ved å trykke her.


### PR DESCRIPTION
Adds the ability to register a user on Nabla.no through the pop-up. The purpose of this is to make the process of registering users more efficient. The code that does this has been commented out, but the comment will be removed at the start of the semester.