### PR TITLE
Removed markdown from lead paragraph on news articles

### DIFF
--- a/templates/includes/info_card.html
+++ b/templates/includes/info_card.html
@@ -38,7 +38,7 @@
             {% endif %}
         </a>
     </h5>
-    <p class="card-text">{{ content.lead_paragraph|markdown:"unsafe" }}</p>
+    <p class="card-text">{{ content.lead_paragraph }}</p>
 
 </div>
 {% if show_details|default:False %}


### PR DESCRIPTION
Fixes #596, decided to remove markdown from the lead paragraph shown at main articles, since it does not use it for it in the article and if you start the sentence with a date it will become a list and default to 1.