### PR TITLE
Office events update

### DIFF
--- a/nablapps/officeCalendar/models.py
+++ b/nablapps/officeCalendar/models.py
@@ -95,13 +95,14 @@ class OfficeEvent(models.Model):
 
         now = datetime.now()
 
-        end_of_week = now + timedelta(days=(6 - now.weekday()))
-        end_of_week = end_of_week.date()
+        # This gives a running window of today plus seven days
+        end_of_window = now + timedelta(days=(7))
+        end_of_window = end_of_window.date()
 
         # Find events this week, but ignore those that have happened
         # Also include all repeating events
         office_events = OfficeEvent.objects.filter(
-            models.Q(start_time__date__gte=now, start_time__date__lte=end_of_week)
+            models.Q(start_time__date__gte=now, start_time__date__lte=end_of_window)
             | models.Q(repeating=True)
         )
 
@@ -111,7 +112,7 @@ class OfficeEvent(models.Model):
         # We can not do database sort, because weekday is not a column
         office_events = sorted(
             office_events,
-            key=lambda event: (event.start_time.weekday(), event.start_time.time()),
+            key=lambda event: (event.start_time.date(), event.start_time.time()),
         )
         return office_events
 

--- a/nablapps/officeCalendar/templates/officeCalendar/includes/list.html
+++ b/nablapps/officeCalendar/templates/officeCalendar/includes/list.html
@@ -53,7 +53,7 @@ office_events is a dictionary with weekday as key and a list of events as value
             <col width="25%">
 {#            <tr>#}
 {#                <th colspan="3" class="text-center card-img-top pt-3 pb-2 bg-secondary no_border">#}
-{#                    <h4 class="text-light">Kontoret denne uka</h4>#}
+{#                    <h4 class="text-light">Kontoret den neste uka</h4>#}
 {#                </th>#}
 {##}
 {#            </tr>#}

--- a/nablapps/officeCalendar/templates/officeCalendar/includes/list.html
+++ b/nablapps/officeCalendar/templates/officeCalendar/includes/list.html
@@ -51,12 +51,6 @@ office_events is a dictionary with weekday as key and a list of events as value
             <col width="20%">
             <col width="55%">
             <col width="25%">
-{#            <tr>#}
-{#                <th colspan="3" class="text-center card-img-top pt-3 pb-2 bg-secondary no_border">#}
-{#                    <h4 class="text-light">Kontoret den neste uka</h4>#}
-{#                </th>#}
-{##}
-{#            </tr>#}
             {% for event in office_events %}
                 {% ifchanged event.start_time.date|date:"w" %}
                     <tr>

--- a/templates/front_page.html
+++ b/templates/front_page.html
@@ -54,7 +54,7 @@
         <!--Kontoret-->
         <div class="office d-flex flex-column">
             <h5 class="nabla-frontpage-header">
-                Kontoret denne uka
+                Kontoret den neste uka
             </h5>
             {% include "officeCalendar/includes/list.html" %}
         </div>


### PR DESCRIPTION
Endret OfficeEvents app slik at den alltid viser events for de neste syv dagene i stedet for kun resten av uka.  
Slik vil det alltid være mulig å se hva som skjer på kontoret over en helg.  
  
Fjernet også noe utkommentert kode som ikke så ut til å være i bruk fra en template-fil.