### PR TITLE
Extract usernames testing

### DIFF
--- a/nablapps/accounts/tests/test_extract_usernames.py
+++ b/nablapps/accounts/tests/test_extract_usernames.py
@@ -6,7 +6,7 @@ from nablapps.accounts.utils import extract_usernames
 
 class TestExtractUsername(TestCase):
     def test_extract_usernames(self):
-        s = "brukernavn@stud.ntnu.no\nannetbrukernavn@stud.ntnu.no"
+        s = "brukernavn\nannetbrukernavn"
         extract_usernames(s)
         self.assertTrue(NablaUser.objects.filter(username="brukernavn").exists())
         self.assertTrue(NablaUser.objects.filter(username="annetbrukernavn").exists())

--- a/nablapps/accounts/utils.py
+++ b/nablapps/accounts/utils.py
@@ -26,7 +26,9 @@ def send_activation_email(user, password):
 def extract_usernames(string, fysmat_class=None):
     from .models import NablaUser, RegistrationRequest
 
-    m = re.findall("([a-z]+)@", string, re.IGNORECASE)
+    # One username per line. Structure of the usernames is 
+    # 'letters+optional numbers'
+    m = re.findall(r"^([a-zæøå]+[1-9]*)\s*$", string, flags = re.IGNORECASE | re.MULTILINE)
     for u in m:
         requests = RegistrationRequest.objects.filter(username=u)
 

--- a/nablapps/accounts/utils.py
+++ b/nablapps/accounts/utils.py
@@ -26,9 +26,11 @@ def send_activation_email(user, password):
 def extract_usernames(string, fysmat_class=None):
     from .models import NablaUser, RegistrationRequest
 
-    # One username per line. Structure of the usernames is 
+    # One username per line. Structure of the usernames is
     # 'letters+optional numbers'
-    m = re.findall(r"^([a-zæøå]+[1-9]*)\s*$", string, flags = re.IGNORECASE | re.MULTILINE)
+    m = re.findall(
+        r"^([a-zæøå]+[1-9]*)\s*$", string, flags=re.IGNORECASE | re.MULTILINE
+    )
     for u in m:
         requests = RegistrationRequest.objects.filter(username=u)
 


### PR DESCRIPTION
Brukernavnene trenger nå ikke en alfakrøll bak; den går etter "End of line" i stedet. Tall aksepteres også så lenge de kommer etter bokstavene. per2 funker, men per2per funker ikke.