### PR TITLE
Remove public application list

### DIFF
--- a/nablapps/apply_committee/templates/apply_committee/admin_application_list.html
+++ b/nablapps/apply_committee/templates/apply_committee/admin_application_list.html
@@ -1,7 +1,7 @@
 {% extends "apply_committee/application_list.html" %}
 
 {% block warning %}
-<b>NB! Du er nå i gruppeledermodus. Det vil si at du kan se anonyme søknader.<br />
+<b>NB! Du er nå i gruppeledermodus, og kan se hvem som har søkt hva. <br />
     With great power comes great responsiblity!</b>
 <div><a href="export.csv"><button class="csv">Eksporter til regneark</button></a></div>
 {% endblock warning %}

--- a/nablapps/apply_committee/templates/apply_committee/apply.html
+++ b/nablapps/apply_committee/templates/apply_committee/apply.html
@@ -57,7 +57,6 @@
 {% if application_round %}
 Nåværende søknad: <u>{{ application_round.name }}</u> <br />
 Skriv kun i fritekst-feltet dersom komiteen har sagt at du skal gjøre dette.<br />
-Du kan se en oversikt over hvem som har søkt hva <a href="{% url 'list-applicants' %}">her</a>.
 <hr />
 <form id="application_form" method="post">
     {% csrf_token %}

--- a/nablapps/apply_committee/templates/apply_committee/apply.html
+++ b/nablapps/apply_committee/templates/apply_committee/apply.html
@@ -70,10 +70,6 @@ Skriv kun i fritekst-feltet dersom komiteen har sagt at du skal gjøre dette.<br
 
         {{ form.application_text.errors }}
         {{ form.application_text }}
-
-        {{ form.anonymous.errors }}
-        {{ form.anonymous.label_tag }}
-        {{ form.anonymous }}
         </div>
     </div>
     {% endfor %}

--- a/nablapps/apply_committee/urls.py
+++ b/nablapps/apply_committee/urls.py
@@ -5,11 +5,10 @@ from . import views
 # This file is included from main url.py under url '^application/'
 urlpatterns = [
     path("", views.ApplicationView.as_view(), name="apply-committee"),
-    path("list/", views.ApplicationListView.as_view(), name="list-applicants"),
     path(
-        "list/admin/",
+        "list/",
         views.AdminApplicationListView.as_view(),
-        name="admin-list-applicants",
+        name="list-applicants",
     ),
     path("confirmation/", views.ConfirmView.as_view(), name="confirm"),
     path("list/admin/export.csv/", views.generate_csv, name="csv"),

--- a/nablapps/apply_committee/urls.py
+++ b/nablapps/apply_committee/urls.py
@@ -11,5 +11,5 @@ urlpatterns = [
         name="list-applicants",
     ),
     path("confirmation/", views.ConfirmView.as_view(), name="confirm"),
-    path("list/admin/export.csv/", views.generate_csv, name="csv"),
+    path("list/export.csv/", views.generate_csv, name="csv"),
 ]

--- a/nablapps/apply_committee/views.py
+++ b/nablapps/apply_committee/views.py
@@ -181,10 +181,6 @@ class BaseApplicationListView(ListView):
         return committees
 
 
-class ApplicationListView(LoginRequiredMixin, BaseApplicationListView):
-    template_name = "apply_committee/application_list.html"
-
-
 class AdminApplicationListView(UserPassesTestMixin, BaseApplicationListView):
     template_name = "apply_committee/admin_application_list.html"
 


### PR DESCRIPTION
Hopefully does exactly what it says, and no more. I recommend having a look at [this issue](https://github.com/Nabla-NTNU/nablaweb/issues/679) for implementation details and more details about what I've tested, however the most important changes are:

1. Removed the open application list
2. Moved the admin list to nabla.no/application/list. **People who are expected to use the admin list should be informed about this**
3. Removed the link to the public application list, as well as the "anonym søknad" button, as all applications are now effectively anonymous. I would suggest updating the slide for the info-meeting to account for this.

I have tried to test everything that should be affected by this and I have fixed all the bugs I have found. However more rigorous testing is always appreciated!