### PR TITLE
changed all 'mailto' email-addresses to use [Ætt] to prevent spam

### DIFF
--- a/nablapps/contact/templates/contact/contact.html
+++ b/nablapps/contact/templates/contact/contact.html
@@ -9,9 +9,9 @@
 <div>
     <h3>For bedriftshenvendelser</h3>
     <p>
-    Kontakt bedriftskontakten på <a href="mailto:bedkom [Ætt] nabla.no">bedkom [Ætt] nabla.no</a>.
+    Kontakt bedriftskontakten på <a href="mailto:">bedkom [Ætt] nabla.no</a>.
     <br>
-    Ev. <a href="mailto:eureka [Ætt] nabla.no">eureka [Ætt] nabla.no</a> for henvendelser vedrørende <b>karrieredagen Eureka.</b>
+    Ev. <a href="mailto:">eureka [Ætt] nabla.no</a> for henvendelser vedrørende <b>karrieredagen Eureka.</b>
     </p>
 </div>
 
@@ -22,7 +22,7 @@
     {% for element in board_emails %}
         <tr>
             <th>{{ element.0 }}</th>
-            <td><a href="mailto:{{ element.1 }} [Ætt] nabla.no">{{ element.1 }} [Ætt] nabla.no</a></td>
+            <td><a href="mailto:">{{ element.1 }} [Ætt] nabla.no</a></td>
         </tr>
     {% endfor %}
 </table>
@@ -33,7 +33,7 @@
     {% for element in nabla_pos_emails %}
         <tr>
             <th>{{ element.0 }}</th>
-            <td><a href="mailto:{{ element.1 }} [Ætt] nabla.no">{{ element.1 }} [Ætt] nabla.no</a></td>
+            <td><a href="mailto:">{{ element.1 }} [Ætt] nabla.no</a></td>
         </tr>
     {% endfor %}
 </table>
@@ -44,7 +44,7 @@
     {% for element in group_emails %}
         <tr>
             <th>{{ element.0 }}</th>
-            <td><a href="mailto:{{ element.1 }} [Ætt] nabla.no">{{ element.1 }} [Ætt] nabla.no</a></td>
+            <td><a href="mailto:">{{ element.1 }} [Ætt] nabla.no</a></td>
         </tr>
     {% endfor %}
 </table>

--- a/nablapps/contact/templates/contact/contact.html
+++ b/nablapps/contact/templates/contact/contact.html
@@ -9,9 +9,9 @@
 <div>
     <h3>For bedriftshenvendelser</h3>
     <p>
-    Kontakt bedriftskontakten på <a href="mailto:bedkom@nabla.no">bedkom [Ætt] nabla.no</a>.
+    Kontakt bedriftskontakten på <a href="mailto:bedkom [Ætt] nabla.no">bedkom [Ætt] nabla.no</a>.
     <br>
-    Ev. <a href="mailto:eureka@nabla.no">eureka [Ætt] nabla.no</a> for henvendelser vedrørende <b>karrieredagen Eureka.</b>
+    Ev. <a href="mailto:eureka [Ætt] nabla.no">eureka [Ætt] nabla.no</a> for henvendelser vedrørende <b>karrieredagen Eureka.</b>
     </p>
 </div>
 
@@ -22,7 +22,7 @@
     {% for element in board_emails %}
         <tr>
             <th>{{ element.0 }}</th>
-            <td><a href="mailto:{{ element.1 }}@nabla.no">{{ element.1 }} [Ætt] nabla.no</a></td>
+            <td><a href="mailto:{{ element.1 }} [Ætt] nabla.no">{{ element.1 }} [Ætt] nabla.no</a></td>
         </tr>
     {% endfor %}
 </table>
@@ -33,7 +33,7 @@
     {% for element in nabla_pos_emails %}
         <tr>
             <th>{{ element.0 }}</th>
-            <td><a href="mailto:{{ element.1 }}@nabla.no">{{ element.1 }} [Ætt] nabla.no</a></td>
+            <td><a href="mailto:{{ element.1 }} [Ætt] nabla.no">{{ element.1 }} [Ætt] nabla.no</a></td>
         </tr>
     {% endfor %}
 </table>
@@ -44,7 +44,7 @@
     {% for element in group_emails %}
         <tr>
             <th>{{ element.0 }}</th>
-            <td><a href="mailto:{{ element.1 }}@nabla.no">{{ element.1 }} [Ætt] nabla.no</a></td>
+            <td><a href="mailto:{{ element.1 }} [Ætt] nabla.no">{{ element.1 }} [Ætt] nabla.no</a></td>
         </tr>
     {% endfor %}
 </table>

--- a/nablapps/contact/templates/contact/for_bedrifter.html
+++ b/nablapps/contact/templates/contact/for_bedrifter.html
@@ -126,8 +126,8 @@
     <div class="row pb-4">
 
         <div class="flex-grow-1 card card-body card-body-overline">
-            <p>Ønsker bedriften din å legge ut en stillingsannonse på denne siden, ta kontakt med Bedriftskontakten Nabla på <a href="mailto:bedkom@nabla.no">
-                bedkom@nabla.no</a>. Les mer om bedriftskontakten <a href="https://nabla.no/komite/bedriftskontakten-nabla/">her</a>.</p>    
+            <p>Ønsker bedriften din å legge ut en stillingsannonse på denne siden, ta kontakt med Bedriftskontakten Nabla på <a href="mailto:bedkom [Ætt] nabla.no">
+                bedkom [Ætt] nabla.no</a>. Les mer om bedriftskontakten <a href="https://nabla.no/komite/bedriftskontakten-nabla/">her</a>.</p>
         </div>
 
     </div>

--- a/nablapps/contact/templates/contact/for_bedrifter.html
+++ b/nablapps/contact/templates/contact/for_bedrifter.html
@@ -126,7 +126,7 @@
     <div class="row pb-4">
 
         <div class="flex-grow-1 card card-body card-body-overline">
-            <p>Ønsker bedriften din å legge ut en stillingsannonse på denne siden, ta kontakt med Bedriftskontakten Nabla på <a href="mailto:bedkom [Ætt] nabla.no">
+            <p>Ønsker bedriften din å legge ut en stillingsannonse på denne siden, ta kontakt med Bedriftskontakten Nabla på <a href="mailto:">
                 bedkom [Ætt] nabla.no</a>. Les mer om bedriftskontakten <a href="https://nabla.no/komite/bedriftskontakten-nabla/">her</a>.</p>
         </div>
 

--- a/nablapps/jobs/templates/jobs/sidebar_include.html
+++ b/nablapps/jobs/templates/jobs/sidebar_include.html
@@ -12,7 +12,7 @@ Vis utløpte: <a href="{{ toggle_expired_link }}" class="text-success fas fa-lg 
 {% endif %}
 
 <h3>Vil du ha stillingsannonsen din her?</h3>
-<p>Ønsker bedriften din å legge ut en stillingsannonse på denne siden, ta kontakt med Bedriftskontakten Nabla på <a href="mailto:bedkom [Ætt] nabla.no">
+<p>Ønsker bedriften din å legge ut en stillingsannonse på denne siden, ta kontakt med Bedriftskontakten Nabla på <a href="mailto:">
 bedkom [Ætt] nabla.no</a>. Les mer om bedriftskontakten <a href="/bedriftskontakten/">her</a>.</p>
 
 {% if jobsidebarinfo %}

--- a/nablapps/jobs/templates/jobs/sidebar_include.html
+++ b/nablapps/jobs/templates/jobs/sidebar_include.html
@@ -12,8 +12,8 @@ Vis utløpte: <a href="{{ toggle_expired_link }}" class="text-success fas fa-lg 
 {% endif %}
 
 <h3>Vil du ha stillingsannonsen din her?</h3>
-<p>Ønsker bedriften din å legge ut en stillingsannonse på denne siden, ta kontakt med Bedriftskontakten Nabla på <a href="mailto:bedkom@nabla.no">
-bedkom@nabla.no</a>. Les mer om bedriftskontakten <a href="/bedriftskontakten/">her</a>.</p>
+<p>Ønsker bedriften din å legge ut en stillingsannonse på denne siden, ta kontakt med Bedriftskontakten Nabla på <a href="mailto:bedkom [Ætt] nabla.no">
+bedkom [Ætt] nabla.no</a>. Les mer om bedriftskontakten <a href="/bedriftskontakten/">her</a>.</p>
 
 {% if jobsidebarinfo %}
     <p>

--- a/nablapps/podcast/templates/podcast/includes/sidebar_include.html
+++ b/nablapps/podcast/templates/podcast/includes/sidebar_include.html
@@ -10,7 +10,7 @@
     mailer oss.
 </p>
 <a href="https://www.facebook.com/skraattkast" class="btn btn-info">Facebook</a>
-<a href="mailto:skrattcast [Ætt] nabla.no" class="btn btn-nabla-blue-dark btn-large">Brevsprekken</a>
+<a href="mailto:" class="btn btn-nabla-blue-dark btn-large">Brevsprekken</a>
 <h2>Skråttcast RSS</h2>
 <p>
     Unngå å gå glipp av en ny episode, abonner på Skråttcast med RSS.

--- a/nablapps/podcast/templates/podcast/includes/sidebar_include.html
+++ b/nablapps/podcast/templates/podcast/includes/sidebar_include.html
@@ -10,7 +10,7 @@
     mailer oss.
 </p>
 <a href="https://www.facebook.com/skraattkast" class="btn btn-info">Facebook</a>
-<a href="mailto:skrattcast@nabla.no" class="btn btn-nabla-blue-dark btn-large">Brevsprekken</a>
+<a href="mailto:skrattcast [Ætt] nabla.no" class="btn btn-nabla-blue-dark btn-large">Brevsprekken</a>
 <h2>Skråttcast RSS</h2>
 <p>
     Unngå å gå glipp av en ny episode, abonner på Skråttcast med RSS.

--- a/static/404/index.html
+++ b/static/404/index.html
@@ -12,6 +12,6 @@
         <p class="wikitext">PS: Nablas egen fagwiki, <a href="http://www.nabla.no/wiki/"><strong>NablaWiki</strong></a>, er fremdeles oppe og går.<br>Her kan du som er ny student lese om
         fagene du skal ha, og få nyttige tips<br>til å på best måte komme deg gjennom tiden din på Fysikk og matematikk.</p>
         <p>PPS: Har du et spørsmål som ikke er besvart på NablaWiki? Send en mail til <a
-            href="mailto:nabla [Ætt] gmail.com">nabla [Ætt] gmail.com</a> &ndash; uansett hva det skulle være!</p>
+            href="mailto:">nabla [Ætt] gmail.com</a> &ndash; uansett hva det skulle være!</p>
     </body>
 </html>

--- a/static/404/index.html
+++ b/static/404/index.html
@@ -12,6 +12,6 @@
         <p class="wikitext">PS: Nablas egen fagwiki, <a href="http://www.nabla.no/wiki/"><strong>NablaWiki</strong></a>, er fremdeles oppe og går.<br>Her kan du som er ny student lese om
         fagene du skal ha, og få nyttige tips<br>til å på best måte komme deg gjennom tiden din på Fysikk og matematikk.</p>
         <p>PPS: Har du et spørsmål som ikke er besvart på NablaWiki? Send en mail til <a
-            href="mailto:kristofferwh@gmail.com">kristofferwh@gmail.com</a> &ndash; uansett hva det skulle være!</p>
+            href="mailto:nabla [Ætt] gmail.com">nabla [Ætt] gmail.com</a> &ndash; uansett hva det skulle være!</p>
     </body>
 </html>

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,7 +1,7 @@
 <h1>500 - Oi da</h1>
 <p>
     Her har det skjedd noe galt! Ta kontakt med webkom på <a
-    href="mailto:webkom@nabla.no">webkom@nabla.no</a>, og fortell så detaljert
+    href="mailto:webkom [Ætt] nabla.no">webkom [Ætt] nabla.no</a>, og fortell så detaljert
 som mulig hva du gjorde når dette skjedde.
 
 <br>

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,7 +1,7 @@
 <h1>500 - Oi da</h1>
 <p>
     Her har det skjedd noe galt! Ta kontakt med webkom på <a
-    href="mailto:webkom [Ætt] nabla.no">webkom [Ætt] nabla.no</a>, og fortell så detaljert
+    href="mailto:">webkom [Ætt] nabla.no</a>, og fortell så detaljert
 som mulig hva du gjorde når dette skjedde.
 
 <br>

--- a/templates/base.html
+++ b/templates/base.html
@@ -495,7 +495,7 @@
                 </div>
                  <div class="col-lg-3 text-center ">
                     <h2>Kontakt</h2>
-{#                        <a class="email" href="mailto:nabla [Ætt] nabla.no">nabla [Ætt] nabla.no</a>#}
+{#                        <a class="email" href="mailto:">nabla [Ætt] nabla.no</a>#}
                         <p > <a href="/contact/">Kontaktside</a> <br>
                         Linjeforeningen Nabla <br>
                         Kjemiblokk 2, Realfagsbygget <br>
@@ -511,7 +511,7 @@
                     <p>
                     Har du funnet en feil, får du ikke logget på, eller er det noe som burde forbedres? <br>
                     Fyll ut <a href="{% url "feedback" %}">tilbakemeldingskjema</a> eller kontakt webkom:<br>
-                    <a class="email" href="mailto:webkom [Ætt] nabla.no">webkom [Ætt] nabla.no</a>
+                    <a class="email" href="mailto:">webkom [Ætt] nabla.no</a>
                     </p>
                 </div>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -495,7 +495,7 @@
                 </div>
                  <div class="col-lg-3 text-center ">
                     <h2>Kontakt</h2>
-{#                        <a class="email" href="mailto:nabla@nabla.no">nabla@nabla.no</a>#}
+{#                        <a class="email" href="mailto:nabla [Ætt] nabla.no">nabla [Ætt] nabla.no</a>#}
                         <p > <a href="/contact/">Kontaktside</a> <br>
                         Linjeforeningen Nabla <br>
                         Kjemiblokk 2, Realfagsbygget <br>
@@ -511,7 +511,7 @@
                     <p>
                     Har du funnet en feil, får du ikke logget på, eller er det noe som burde forbedres? <br>
                     Fyll ut <a href="{% url "feedback" %}">tilbakemeldingskjema</a> eller kontakt webkom:<br>
-                    <a class="email" href="mailto:webkom@nabla.no">webkom@nabla.no</a>
+                    <a class="email" href="mailto:webkom [Ætt] nabla.no">webkom [Ætt] nabla.no</a>
                     </p>
                 </div>
 

--- a/templates/front_page.html
+++ b/templates/front_page.html
@@ -29,7 +29,7 @@
                 </a>
                 <p></p>
             {% endif %}
-            <a href="mailto:bedriftskontakt@nabla.no" class="btn btn-nabla-blue-dark">
+            <a href="mailto:bedriftskontakt [Ætt] nabla.no" class="btn btn-nabla-blue-dark">
                 Bedriftsforslag - send en mail til BN
             </a>
             <p></p>
@@ -115,7 +115,7 @@
                 <h4 class="text-nabla-blue">Bedrift?</h4>
                 <p>
                     Sjekk ut <a href="/bedriftskontakten/">bedriftskontakten sine sider</a>, eller ta kontakt med
-                    bedriftskontakten på <a href="mailto:bedkom@nabla.no">bedkom@nabla.no</a>.
+                    bedriftskontakten på <a href="mailto:bedkom [Ætt] nabla.no">bedkom [Ætt] nabla.no</a>.
                 </p>
             </div>
         {% endif %}

--- a/templates/front_page.html
+++ b/templates/front_page.html
@@ -29,7 +29,7 @@
                 </a>
                 <p></p>
             {% endif %}
-            <a href="mailto:bedriftskontakt [Ætt] nabla.no" class="btn btn-nabla-blue-dark">
+            <a href="mailto:" class="btn btn-nabla-blue-dark">
                 Bedriftsforslag - send en mail til BN
             </a>
             <p></p>
@@ -115,7 +115,7 @@
                 <h4 class="text-nabla-blue">Bedrift?</h4>
                 <p>
                     Sjekk ut <a href="/bedriftskontakten/">bedriftskontakten sine sider</a>, eller ta kontakt med
-                    bedriftskontakten på <a href="mailto:bedkom [Ætt] nabla.no">bedkom [Ætt] nabla.no</a>.
+                    bedriftskontakten på <a href="mailto:">bedkom [Ætt] nabla.no</a>.
                 </p>
             </div>
         {% endif %}

--- a/templates/old-front_page.html
+++ b/templates/old-front_page.html
@@ -147,7 +147,7 @@
         </p>
         <h4>Bedrift?</h4>
         <p>
-            Ta kontakt med bedriftskontakten på <a href="mailto:bedkom [Ætt] nabla.no">bedkom [Ætt] nabla.no.</a>
+            Ta kontakt med bedriftskontakten på <a href="mailto:">bedkom [Ætt] nabla.no.</a>
         </p>
     </div
     {% include "poll/poll_include.html" %}

--- a/templates/old-front_page.html
+++ b/templates/old-front_page.html
@@ -147,7 +147,7 @@
         </p>
         <h4>Bedrift?</h4>
         <p>
-            Ta kontakt med bedriftskontakten på <a href="mailto:bedkom@nabla.no">bedkom@nabla.no.</a>
+            Ta kontakt med bedriftskontakten på <a href="mailto:bedkom [Ætt] nabla.no">bedkom [Ætt] nabla.no.</a>
         </p>
     </div
     {% include "poll/poll_include.html" %}


### PR DESCRIPTION
Changed the format of all links of the form
```
mailto:<name>@<domain>
```
to
```
mailto:<name> [Ætt] <domain>
```
in an attempt to reduce the amount of spam we recieve. This should still be obvious to human beings what we mean, but bots might have a harder time.