### PR TITLE
personal website link bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ sqlite.db
 
 # Private keys / data
 lib/privateKey.json
+
+# macOS (sorry)
+.DS_Store
+**/.DS_Store

--- a/nablapps/accounts/templates/accounts/view_member_profile.html
+++ b/nablapps/accounts/templates/accounts/view_member_profile.html
@@ -40,9 +40,9 @@
             <tr>
                 <td>Hjemmeside </td>
                 {% if member.web_page %}
-                <td><a href="{{ member.web_page }}" target="_blank" >{{ member.web_page }}</a></td>
+                <td><a href="https://{{ member.web_page }}" target="_blank" >{{ member.web_page }}</a></td>
                 {% else %}
-                <td><a href="http://folk.ntnu.no/{{ member.username }}">http://folk.ntnu.no/{{ member.username }}</a></td>
+                <td><a href="https://folk.ntnu.no/{{ member.username }}">folk.ntnu.no/{{ member.username }}</a></td>
                 {% endif %}
             </tr>
 

--- a/nablapps/accounts/views.py
+++ b/nablapps/accounts/views.py
@@ -35,6 +35,12 @@ class UserDetailView(LoginRequiredMixin, DetailView):
     def get_object(self, queryset=None):
         try:
             view_user = NablaUser.objects.get(username=self.kwargs["username"])
+
+            # Folk lagrer med og uten protokoll - må normaliseres for å funke
+            if view_user.web_page:
+                view_user.web_page = view_user.web_page.removeprefix("http://")
+                view_user.web_page = view_user.web_page.removeprefix("https://")
+
         except NablaUser.DoesNotExist:
             raise Http404("Bruker finnes ikke")
         return view_user


### PR DESCRIPTION
Vi har en bug her foreksempel [profilsida mi](https://nabla.no/brukere/view/alexamm/) (og også andre webkommere) prøver å lenke til [tsbw.no](tsbw.no), men lenker i stedet til [https://nabla.no/brukere/view/alexamm/tsbw.no](https://nabla.no/brukere/view/alexamm/tsbw.no).

Dette er fordi nablabrukerens personlige nettside `member.web_page` feedes direkte inn i anchor-taggen, som er litt ødelagt dersom noen ikke viser til protokoll, da leses det som en lenke på [nabla.no](nabla.no). I databasen har vi litt over 40 lenker, alle er enten ødelagte eller funker med https.

Denne løsningen stripper stripper `http://` og `https//` fra strengen i `UserDetailView` før den sendes til templaten. I templaten vises lenken uten protokoll, men den peker på `https`, siden det ikke ødelegger for noen, og jeg tviler at noen skal få veldig lyst til å lenke en side uten TLS i nærmeste framtid (ref. 42 brukerlenker i databasen per i dag)

La også inn `.DS_Store` i gitignore, håper det er greit. Vil redusere sjansene for noe uheldig da det tydeligvis har krypt inn et par på systemet mitt.